### PR TITLE
added support for argon2 hash and compatible with nodejs lib `https://github.com/ranisalt/node-argon2.git`

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -125,6 +125,7 @@ const (
 	CodeArgon2EncodeHashError
 	CodeArgon2DecodeHashError
 	CodeArgon2IncompatibleVersion
+	CodeArgon2NotMatch
 	// Other codes
 )
 

--- a/cryptography/argon2.go
+++ b/cryptography/argon2.go
@@ -42,7 +42,7 @@ type argon2impl struct {
 	b64enc      base64.Encoding
 }
 
-// Create argon2 hash with default parameter. Compatible with nodejs library `github.com/ranisalt/node-argon2` if you set `memory = 65536` and `parallelism = 3` because default parameter of my lib is `memory = 4096` and `parallelism = 1`
+// Create argon2 hash with default parameter. Compatible with nodejs library `https://github.com/ranisalt/node-argon2.git` if you set `memory = 65536` and `parallelism = 4` because default parameter of my lib is `memory = 4096` and `parallelism = 1`
 func NewArgon2() Argon2 {
 	result := &argon2impl{
 		delimiter:   "$",

--- a/cryptography/argon2.go
+++ b/cryptography/argon2.go
@@ -18,6 +18,15 @@ type Argon2 interface {
 
 	// Compare plain text with hash argon2, return `true`` and error `nil` if equal
 	Compare(text, hashedText []byte) (bool, error)
+
+	// Set memory for argon2 parameter
+	SetMemory(memory uint32) Argon2
+
+	// Set iterations for argon2 parameter
+	SetIterations(iterations uint32) Argon2
+
+	// Set parallelism for argon2 parameter
+	SetParallelism(parallelism uint8) Argon2
 }
 
 type argon2impl struct {
@@ -33,7 +42,7 @@ type argon2impl struct {
 	b64enc      base64.Encoding
 }
 
-// Create argon2 hash with default parameter
+// Create argon2 hash with default parameter. Compatible with nodejs library `github.com/ranisalt/node-argon2` if you set `memory = 65536` and `parallelism = 3` because default parameter of my lib is `memory = 4096` and `parallelism = 1`
 func NewArgon2() Argon2 {
 	result := &argon2impl{
 		delimiter:   "$",
@@ -45,7 +54,7 @@ func NewArgon2() Argon2 {
 		keyLen:      32,
 		memory:      (4 * 1024),
 		version:     argon2.Version,
-		b64enc:      *base64.StdEncoding.Strict(),
+		b64enc:      *base64.RawStdEncoding.Strict(),
 	}
 
 	return result
@@ -127,4 +136,19 @@ func (a *argon2impl) decodeKey(key []byte) (*argon2impl, []byte, error) {
 	arg.keyLen = uint32(len(key))
 
 	return arg, key, nil
+}
+
+func (a *argon2impl) SetMemory(memory uint32) Argon2 {
+	a.memory = memory
+	return a
+}
+
+func (a *argon2impl) SetIterations(iterations uint32) Argon2 {
+	a.iterations = iterations
+	return a
+}
+
+func (a *argon2impl) SetParallelism(parallelism uint8) Argon2 {
+	a.parallelism = parallelism
+	return a
 }

--- a/cryptography/argon2.go
+++ b/cryptography/argon2.go
@@ -1,0 +1,74 @@
+package cryptography
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/irdaislakhuafa/go-sdk/codes"
+	"github.com/irdaislakhuafa/go-sdk/errors"
+	"golang.org/x/crypto/argon2"
+)
+
+type Argon2 interface {
+	// Hash text with argon2 algorithm with format from `hashFormat` or you can determine your specific format
+	Hash(text []byte) (string, error)
+
+	// Compare plain text with hash argon2, return `true`` and error `nil` if equal
+	Compare(text, hashedText []byte) (bool, error)
+}
+
+type argon2impl struct {
+	delimiter   string
+	lengthValue uint64
+	hashFormat  string
+	salt        []byte
+	iterations  uint32
+	parallelism uint8
+	keyLen      uint32
+	memory      uint32
+	version     int
+}
+
+// Create argon2 hash with default parameter
+func NewArgon2() Argon2 {
+	result := &argon2impl{
+		delimiter:   "$",
+		lengthValue: 6,
+		hashFormat:  "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		salt:        make([]byte, 16),
+		iterations:  3,
+		parallelism: 1,
+		keyLen:      32,
+		memory:      (4 * 1024),
+		version:     argon2.Version,
+	}
+
+	return result
+}
+
+func (a *argon2impl) Hash(text []byte) (string, error) {
+	if _, err := rand.Read(a.salt); err != nil {
+		return "", errors.NewWithCode(codes.CodeArgon2, "failed to make salt, %v", err)
+	}
+
+	key := argon2.IDKey(text, a.salt, a.iterations, a.memory, a.parallelism, a.keyLen)
+	encodedKey, err := a.encodeKey(key)
+	if err != nil {
+		return "", errors.NewWithCode(codes.CodeArgon2, "failed to encode key with argon2, %v", err)
+	}
+
+	return encodedKey, nil
+}
+
+func (a *argon2impl) Compare(text []byte, hashedText []byte) (bool, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *argon2impl) encodeKey(key []byte) (string, error) {
+	enc := base64.StdEncoding
+	base64Salt := enc.EncodeToString(a.salt)
+	base64Key := enc.EncodeToString(key)
+	encodedKey := fmt.Sprintf(a.hashFormat, a.version, a.memory, a.iterations, a.parallelism, base64Salt, base64Key)
+	return encodedKey, nil
+}

--- a/cryptography/argon2_test.go
+++ b/cryptography/argon2_test.go
@@ -1,0 +1,130 @@
+package cryptography
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/irdaislakhuafa/go-sdk/codes"
+	"github.com/irdaislakhuafa/go-sdk/errors"
+	"github.com/irdaislakhuafa/go-sdk/files"
+)
+
+func Test_Argon2(t *testing.T) {
+	type Mode int
+	const (
+		MODE_HASH = Mode(iota)
+		MODE_COMPARE
+	)
+
+	type param struct {
+		plainText  string
+		hashedText string
+	}
+
+	type wantResult struct {
+		isEqual  bool
+		isArgon2 bool
+	}
+
+	type wantErr struct {
+		errCode codes.Code
+	}
+
+	type test struct {
+		name       string
+		mode       Mode
+		algFunc    Argon2
+		param      param
+		isWantErr  bool
+		wantResult wantResult
+		wantErr    wantErr
+	}
+
+	tests := []test{
+		{
+			name:       "test hash success",
+			mode:       MODE_HASH,
+			algFunc:    NewArgon2(),
+			param:      param{plainText: "password"},
+			isWantErr:  false,
+			wantErr:    wantErr{},
+			wantResult: wantResult{isArgon2: true},
+		},
+		{
+			name:       "compare hash success",
+			mode:       MODE_COMPARE,
+			algFunc:    NewArgon2(),
+			param:      param{plainText: "password", hashedText: "$argon2id$v=19$m=4096,t=3,p=1$5Jr6f1VGhrzIRCfUu8VlBQ$xhbrJs0FhNIBR+/vvCkUxcrcDZc0G2xc3ipqstj9H3A"},
+			isWantErr:  false,
+			wantResult: wantResult{isEqual: true},
+			wantErr:    wantErr{},
+		},
+		{
+			name:       "compare hash failed or false",
+			mode:       MODE_COMPARE,
+			algFunc:    NewArgon2(),
+			param:      param{plainText: "x", hashedText: "$argon2id$v=19$m=4096,t=3,p=1$5Jr6f1VGhrzIRCfUu8VlBQ$xhbrJs0FhNIBR+/vvCkUxcrcDZc0G2xc3ipqstj9H3A"},
+			isWantErr:  false,
+			wantResult: wantResult{isEqual: false},
+			wantErr:    wantErr{},
+		},
+		{
+			name:       "compatibility test ok with hashed text from https://github.com/ranisalt/node-argon2.git",
+			mode:       MODE_COMPARE,
+			algFunc:    NewArgon2().SetIterations(3).SetParallelism(4).SetMemory(65536),
+			param:      param{plainText: "password", hashedText: "$argon2id$v=19$m=65536,t=3,p=4$AL7pBy/YmGyqSOH4/LCWMQ$Z7Pan4USduRrdZkYIIVvRBjbYwT+pDAszV/qqYt3Y+A"},
+			isWantErr:  false,
+			wantResult: wantResult{isEqual: true},
+			wantErr:    wantErr{},
+		},
+	}
+
+	f := files.GetCurrentMethodName()
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v:%v:%v", f, tt.mode, tt.name), func(t *testing.T) {
+			switch tt.mode {
+			case MODE_HASH:
+				result, err := tt.algFunc.Hash([]byte(tt.param.plainText))
+				if tt.isWantErr {
+					if err == nil {
+						t.Fatalf("want err is %#v but got err %#v", tt.isWantErr, err)
+					}
+
+					if code := errors.GetCode(err); tt.wantErr.errCode != code {
+						t.Fatalf("want err code is %#v but got %#v with msg %#v", tt.wantErr.errCode, code, err)
+					}
+				} else {
+					if strings.Contains(result, "$argon2id$v=") == tt.wantResult.isArgon2 {
+						t.Logf("result is argon2 %#v", result)
+					}
+				}
+
+			case MODE_COMPARE:
+				isOk, err := tt.algFunc.Compare([]byte(tt.param.plainText), []byte(tt.param.hashedText))
+				if tt.isWantErr {
+					if err == nil {
+						t.Fatalf("want err is %#v but got err %#v", tt.isWantErr, err)
+					}
+
+					if code := errors.GetCode(err); tt.wantErr.errCode != code {
+						t.Fatalf("want err code is %#v but got %#v with msg %#v", tt.wantErr.errCode, code, err)
+					}
+				} else {
+					// if tt.wantResult.isEqual {
+					if isOk != tt.wantResult.isEqual {
+						t.Fatalf("want result is %#v for params %#v == %#v", tt.wantResult.isEqual, tt.param.plainText, tt.param.hashedText)
+					} else {
+						t.Logf("compare result for params %#v = %#v is %#v want is %#v", tt.param.hashedText, tt.param.plainText, isOk, tt.wantResult.isEqual)
+					}
+					// } else {
+					// 	if isOk == tt.wantResult.isEqual {
+					// 		t.Fatalf("want result is %#v for params %#v = %#v but got %#v", tt.wantResult.isEqual, tt.param.hashedText, tt.param.plainText, isOk)
+					// 	}
+					// }
+				}
+			}
+		})
+		fmt.Println("")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/irdaislakhuafa/go-sdk
 
 go 1.20
 
-require (
-	github.com/google/uuid v1.4.0
-	github.com/rs/zerolog v1.31.0
-)
+require github.com/rs/zerolog v1.31.0
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -11,7 +9,11 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
- added interface and implementation method to hash with argon2 algorithm
- added argon2 method to compare argon2 hash
- added method to custom memory, iterations and parallelism
- added unit test to test hashing method for argon2. with hash, compare and compatibility test with `https://github.com/ranisalt/node-argon2.git` as nodejs lib
