### PR TITLE
refactor(appcontext): Rename context keys to uppercase

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -11,64 +11,64 @@ import (
 type contextKey string
 
 const (
-	acceptLanguage   contextKey = "AcceptLanguage"
-	requestID        contextKey = "RequestID"
-	serviceVersion   contextKey = "ServiceVersion"
-	userAgent        contextKey = "UserAgent"
-	requestStartTime contextKey = "RequestStartTime"
+	AcceptLanguage   contextKey = "AcceptLanguage"
+	RequestID        contextKey = "RequestID"
+	ServiceVersion   contextKey = "ServiceVersion"
+	UserAgent        contextKey = "UserAgent"
+	RequestStartTime contextKey = "RequestStartTime"
 )
 
 // Set accept language to context
 func SetAcceptLanguage(ctx context.Context, lang language.Language) context.Context {
-	return context.WithValue(ctx, acceptLanguage, lang)
+	return context.WithValue(ctx, AcceptLanguage, lang)
 }
 
 // Get accept language from context and if not exists, this function will return `language.English` as default value
 func GetAcceptLanguage(ctx context.Context) language.Language {
-	acceptLanguage, isOk := ctx.Value(acceptLanguage).(string)
+	acceptLanguage, isOk := ctx.Value(AcceptLanguage).(string)
 	return operator.Ternary[language.Language](!isOk, language.English, language.Language(acceptLanguage))
 }
 
 // Set request id to context
 func SetRequestID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, requestID, id)
+	return context.WithValue(ctx, RequestID, id)
 }
 
 // Get request id from context and will return empty string if not exist
 func GetRequestID(ctx context.Context) string {
-	requestID, isOk := ctx.Value(requestID).(string)
+	requestID, isOk := ctx.Value(RequestID).(string)
 	return operator.Ternary[string](!isOk, "", requestID)
 }
 
 // Set service version to context
 func SetServiceVersion(ctx context.Context, version string) context.Context {
-	return context.WithValue(ctx, serviceVersion, version)
+	return context.WithValue(ctx, ServiceVersion, version)
 }
 
 // Get service version from context and will return empty string if not exist
 func GetServiceVersion(ctx context.Context) string {
-	serviceVersion, isOk := ctx.Value(serviceVersion).(string)
+	serviceVersion, isOk := ctx.Value(ServiceVersion).(string)
 	return operator.Ternary[string](!isOk, "", serviceVersion)
 }
 
 // Set user agent to context
 func SetUserAgent(ctx context.Context, ua string) context.Context {
-	return context.WithValue(ctx, userAgent, ua)
+	return context.WithValue(ctx, UserAgent, ua)
 }
 
 // Get user agent from context and will return empty string if not exist
 func GetUserAgent(ctx context.Context) string {
-	userAgent, isOk := ctx.Value(userAgent).(string)
+	userAgent, isOk := ctx.Value(UserAgent).(string)
 	return operator.Ternary[string](!isOk, "", userAgent)
 }
 
 // Set request start time to context
 func SetRequestStartTime(ctx context.Context, rst time.Time) context.Context {
-	return context.WithValue(ctx, requestStartTime, rst)
+	return context.WithValue(ctx, RequestStartTime, rst)
 }
 
 // Get request start time from context will return zero value of `time.Time` if not exist
 func GetRequestStartTime(ctx context.Context) time.Time {
-	requestStartTime, isOk := ctx.Value(requestStartTime).(time.Time)
+	requestStartTime, isOk := ctx.Value(RequestStartTime).(time.Time)
 	return operator.Ternary[time.Time](!isOk, time.Time{}, requestStartTime)
 }

--- a/appcontext/appcontext_test.go
+++ b/appcontext/appcontext_test.go
@@ -35,7 +35,7 @@ func Test_Appcontext_acceptLanguage(t *testing.T) {
 			name: "test SetAcceptLanguage success",
 			mode: SET,
 			args: args{ctx: context.Background(), lang: language.Indonesian},
-			want: want{value: context.WithValue(context.Background(), acceptLanguage, language.Indonesian)},
+			want: want{value: context.WithValue(context.Background(), AcceptLanguage, language.Indonesian)},
 		},
 		{
 			name: "test GetAcceptLanguage success with default language",


### PR DESCRIPTION
This commit renames context keys from lowercase to uppercase to improve readability and consistency within the codebase. The previous naming convention was inconsistent and made it difficult to distinguish between different context keys. This change will make it easier to identify and use the correct context keys.
