### PR TITLE
refactor(appcontext): remove useless operator package

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -26,7 +26,7 @@ func SetAcceptLanguage(ctx context.Context, lang language.Language) context.Cont
 // Get accept language from context and if not exists, this function will return `language.English` as default value
 func GetAcceptLanguage(ctx context.Context) language.Language {
 	acceptLanguage, isOk := ctx.Value(AcceptLanguage).(string)
-	return operator.Ternary[language.Language](!isOk, language.English, language.Language(acceptLanguage))
+	return operator.Ternary(!isOk, language.English, language.Language(acceptLanguage))
 }
 
 // Set request id to context
@@ -37,7 +37,7 @@ func SetRequestID(ctx context.Context, id string) context.Context {
 // Get request id from context and will return empty string if not exist
 func GetRequestID(ctx context.Context) string {
 	requestID, isOk := ctx.Value(RequestID).(string)
-	return operator.Ternary[string](!isOk, "", requestID)
+	return operator.Ternary(!isOk, "", requestID)
 }
 
 // Set service version to context
@@ -48,7 +48,7 @@ func SetServiceVersion(ctx context.Context, version string) context.Context {
 // Get service version from context and will return empty string if not exist
 func GetServiceVersion(ctx context.Context) string {
 	serviceVersion, isOk := ctx.Value(ServiceVersion).(string)
-	return operator.Ternary[string](!isOk, "", serviceVersion)
+	return operator.Ternary(!isOk, "", serviceVersion)
 }
 
 // Set user agent to context
@@ -59,7 +59,7 @@ func SetUserAgent(ctx context.Context, ua string) context.Context {
 // Get user agent from context and will return empty string if not exist
 func GetUserAgent(ctx context.Context) string {
 	userAgent, isOk := ctx.Value(UserAgent).(string)
-	return operator.Ternary[string](!isOk, "", userAgent)
+	return operator.Ternary(!isOk, "", userAgent)
 }
 
 // Set request start time to context
@@ -70,5 +70,5 @@ func SetRequestStartTime(ctx context.Context, rst time.Time) context.Context {
 // Get request start time from context will return zero value of `time.Time` if not exist
 func GetRequestStartTime(ctx context.Context) time.Time {
 	requestStartTime, isOk := ctx.Value(RequestStartTime).(time.Time)
-	return operator.Ternary[time.Time](!isOk, time.Time{}, requestStartTime)
+	return operator.Ternary(!isOk, time.Time{}, requestStartTime)
 }


### PR DESCRIPTION
Remove useless operator package.

This commit removes the operator package from the appcontext package, as it is no longer needed. The operator package was used to provide ternary operators, which are now available in the standard library.

This change simplifies the appcontext package and makes it more maintainable.
