### PR TITLE
fix(errors): get runtime caller from correct location

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -82,7 +82,7 @@ func create(cause error, code codes.Code, msg string, val ...any) error {
 		line:     0,
 	}
 
-	pc, file, line, isOk := runtime.Caller(1)
+	pc, file, line, isOk := runtime.Caller(2)
 	if !isOk {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+
+	"github.com/irdaislakhuafa/go-sdk/codes"
+	"github.com/irdaislakhuafa/go-sdk/errors"
+	"github.com/irdaislakhuafa/go-sdk/log"
+)
+
+func main() {
+	l := log.Init(log.Config{Level: "debug"})
+	err := errors.NewWithCode(codes.CodeBadRequest, "haha")
+	l.Debug(context.Background(), err)
+}


### PR DESCRIPTION
Fixes the issue where the runtime caller was not being retrieved from the correct location in the stack trace. This could lead to incorrect error messages being generated.

The changes in this commit update the runtime caller retrieval location to be the correct location in the stack trace and fix the issue.
