### PR TITLE
feat(datastructure): add convenience methods IsEmpty and Size to Set data structure

### DIFF
--- a/datastructure/set.go
+++ b/datastructure/set.go
@@ -10,6 +10,8 @@ type SetInterface[E comparable] interface {
 	Del(values ...E)
 	Slice() []E
 	Clear()
+	IsEmpty() bool
+	Size() int
 }
 
 // Set data type is like `slice` or `array` but without duplicate element and set element is unordered element
@@ -52,4 +54,12 @@ func (s *Set[E]) Slice() []E {
 
 func (s *Set[E]) Clear() {
 	clear(s.Values)
+}
+
+func (s *Set[E]) IsEmpty() bool {
+	return len(s.Values) == 0
+}
+
+func (s *Set[E]) Size() int {
+	return len(s.Values)
 }


### PR DESCRIPTION
Adds two convenience methods to the Set data structure:

- `IsEmpty()` returns whether the set is empty.
- `Size()` returns the number of elements in the set.
