### PR TITLE
fix(concurrency): add lock and unlock to AddError

### DIFF
--- a/concurrency/concurrency.go
+++ b/concurrency/concurrency.go
@@ -31,7 +31,7 @@ type Interface interface {
 	// To flag wait group if proccess is done. This like wg.Done()
 	Done()
 
-	// Added errors if have error. The error will be returned at Do() method if exists. Recommended to use errors.NewWithCode()
+	// Added errors if have error. This method already implement c.Lock() and c.Unlock(). The error will be returned at Do() method if exists. Recommended to use errors.NewWithCode()
 	AddError(errs ...error)
 }
 


### PR DESCRIPTION
Add Lock() and Unlock() to AddError to prevent data races.
