### PR TITLE
feat(concurrency): add func that will be run async at goroutine

### DIFF
--- a/concurrency/concurrency.go
+++ b/concurrency/concurrency.go
@@ -19,7 +19,7 @@ type Interface interface {
 	// Run the list functions with goroutine
 	Do(ctx context.Context) error
 
-	// Added function that will be run async at goroutine. Call c.Done() after process is complete
+	// Added function that will be run async at goroutine. This method already call c.Done() after process is complete
 	AddFunc(fn func(ctx context.Context, c Interface))
 
 	// Lock block of code. This like mt.Lock()
@@ -89,7 +89,10 @@ func (c *concurrency) Do(ctx context.Context) error {
 }
 
 func (c *concurrency) AddFunc(fn func(ctx context.Context, c Interface)) {
-	c.listFunc = append(c.listFunc, fn)
+	c.listFunc = append(c.listFunc, func(ctx context.Context, c Interface) {
+		defer c.Done()
+		fn(ctx, c)
+	})
 }
 
 func (c *concurrency) Lock() {


### PR DESCRIPTION
This commit adds a new function to the concurrency package that will be run asynchronously at goroutine. This function already calls c.Done() after the process is complete, which simplifies the usage of the concurrency package.

BREAKING CHANGE: The signature of the AddFunc function has changed. The new signature is:

```
func AddFunc(fn func(ctx context.Context, c Interface))
```
