### PR TITLE
refactor(concurrency): add GetMaxWorker() method

### DIFF
--- a/concurrency/concurrency.go
+++ b/concurrency/concurrency.go
@@ -36,6 +36,9 @@ type Interface interface {
 
 	// To clear list functions
 	ClearFunc()
+
+	// Get value of maximum worker
+	GetMaxWorker() int64
 }
 
 type concurrency struct {
@@ -119,4 +122,8 @@ func (c *concurrency) AddError(errs ...error) {
 
 func (c *concurrency) ClearFunc() {
 	c.listFunc = nil
+}
+
+func (c *concurrency) GetMaxWorker() int64 {
+	return c.maxWorker
 }


### PR DESCRIPTION
Add a GetMaxWorker() method to the concurrency interface to retrieve the maximum number of workers configured for the concurrency pool.

This method allows clients to easily access the maximum worker configuration, which can be useful for debugging and performance tuning.
