### PR TITLE
feat: clone concurrency with empty function list

### DIFF
--- a/concurrency/concurrency.go
+++ b/concurrency/concurrency.go
@@ -39,6 +39,9 @@ type Interface interface {
 
 	// Get value of maximum worker
 	GetMaxWorker() int64
+
+	// Create clone object of this concurrency with empty list function or etc but with same max worker
+	Clone() Interface
 }
 
 type concurrency struct {
@@ -126,4 +129,8 @@ func (c *concurrency) ClearFunc() {
 
 func (c *concurrency) GetMaxWorker() int64 {
 	return c.maxWorker
+}
+
+func (c *concurrency) Clone() Interface {
+	return NewConcurrency().WithMaxWorker(c.maxWorker)
 }


### PR DESCRIPTION
This commit introduces a `Clone` function to the `Concurrency` interface. The `Clone` function allows for the creation of a new `Concurrency` object with the same max worker as the original object, but with an empty list of functions.

This is useful in cases where you want to create a new `Concurrency` object with the same max worker as an existing object, but you do not want to copy over the list of functions from the original object.
