### PR TITLE
fix(errors): update error caller line number

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -41,7 +41,7 @@ func Test_GetCaller(t *testing.T) {
 			args: args{err: NewWithCode(codes.CodeBadRequest, "bad request")},
 			wantResult: wantResult{
 				file:    files.GetCurrentFileLocation(), // NOTE: this is line where error created with function NewWithCode
-				line:    37,
+				line:    41,
 				message: "bad request",
 			},
 			wantErr: wantErr{isWanted: false},
@@ -56,7 +56,7 @@ func Test_GetCaller(t *testing.T) {
 			},
 			wantErr: wantErr{
 				isWanted: true,
-				errMsg:   "failed to cast error to stacktrace",
+				errMsg:   "pure error",
 			},
 		},
 	}


### PR DESCRIPTION
Updates error caller line number to reflect the line where the error was created with the NewWithCode function.

BREAKING CHANGE: The error caller line number now reflects the line where the error was created with the NewWithCode function. This may cause errors to be reported with a different line number than before.
