### PR TITLE
style: alias TmplWithoutErr to TWE

### DIFF
--- a/strformat/strformat.go
+++ b/strformat/strformat.go
@@ -44,4 +44,4 @@ func TmplWithoutErr(tmplFormat string, values any) string {
 var T = Tmpl
 
 // Alias of `strformat.TmplWithoutErr`
-var TE = TmplWithoutErr
+var TWE = TmplWithoutErr


### PR DESCRIPTION
Aliases TmplWithoutErr to TWE to reduce variable name length.
