### PR TITLE
feat(collections): add function IsElementsEquals

### DIFF
--- a/collections/slice_test.go
+++ b/collections/slice_test.go
@@ -1,0 +1,44 @@
+package collections
+
+import "testing"
+
+func Test_IsElementEquals(t *testing.T) {
+	type (
+		params struct {
+			param1, param2 []string
+		}
+		test struct {
+			name       string
+			params     params
+			wantResult bool
+		}
+	)
+
+	tests := []test{
+		{
+			name: "element should equals",
+			params: params{
+				param1: []string{"A", "B", "C"},
+				param2: []string{"B", "C", "A"},
+			},
+			wantResult: true,
+		},
+		{
+			name: "element should not equals",
+			params: params{
+				param1: []string{"A", "B", "C"},
+				param2: []string{"A", "B"},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsElementsEquals(tt.params.param1, tt.params.param2)
+			if tt.wantResult != result {
+				t.Fatalf("param1: '%+v', param2: '%+v', want result '%+v' but got '%+v'\n", tt.params.param1, tt.params.param2, tt.wantResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new function `IsElementsEquals` to the `collections` package that checks if two slices of strings have the same elements.

This function is useful for comparing the elements of two slices without regard to their order. It can be used to check if two sets of strings are equal, or to find the intersection or union of two sets of strings.
